### PR TITLE
vonk: renamed firely server import to ingest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+._buildhtml
 _build/
 .vscode/
 /.vs/slnx.sqlite

--- a/performance/performance_firely_server.rst
+++ b/performance/performance_firely_server.rst
@@ -102,7 +102,7 @@ Data
 
 Performance testing is best done with data as realistic to your situation as possible. So if you happen to have historic data that you can transform to FHIR resources, that is the best data to test with.
 
-But if you don't have data of your own, you can use synthesized data. We use data from the Synthea project for our own tests. And we provide :ref:`VonkLoader<vonkloader_index>` to upload the collection bundles from Synthea to Firely Server (or any FHIR Server for that matter). 
+But if you don't have data of your own, you can use synthesized data. We use data from the Synthea project for our own tests. And we provide :ref:`tool_fsi` to upload the collection bundles from Synthea to Firely Server (or any FHIR Server for that matter). 
 
 If you build a Facade, the historical data is probably already in a test environment of the system you build the Facade on. That is a perfect start.
 

--- a/tools/firely-server-import.rst
+++ b/tools/firely-server-import.rst
@@ -1,9 +1,9 @@
 .. _tool_fsi:
 
-Firely Server Import (FSI)
+Firely Server Ingest (FSI)
 ==========================
 
-**Firely Server Import (FSI)** is a CLI application designed to optimize massive resource ingestion into a Firely Server instance. In contrast to resource ingestion by sending HTTP requests to a running Firely Server instance, this tool writes data directly to the underlying FS database which increases the throughput significantly.
+**Firely Server Ingest (FSI)** is a CLI application designed to optimize massive resource ingestion into a Firely Server instance. In contrast to resource ingestion by sending HTTP requests to a running Firely Server instance, this tool writes data directly to the underlying FS database which increases the throughput significantly.
 
 .. note::
 


### PR DESCRIPTION
Renamed Firely Server Import to Ingest. Replaced VonkLoader reference with FSI.