### PR TITLE
adjusted stylesheet for better scaling

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: ./conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/_static/css/style.css
+++ b/_static/css/style.css
@@ -70,9 +70,8 @@ a.icon-home:hover {
 
 }
 .wy-nav-content {
-	max-width: 800px;
+	max-width: 95%;
 	width: 100%;
-
 	word-wrap: break-word;
 }
 

--- a/getting_started/binary.rst
+++ b/getting_started/binary.rst
@@ -64,5 +64,6 @@ You will see the following homepage:
    
 .. image:: ../images/localhost_home.png
   :align: center
+  :width: 760px
 
 The next step is to explore Firely Server functionality using Postman. The section :ref:`postman_tutorial` will guide you through this.

--- a/getting_started/postman_tutorial.rst
+++ b/getting_started/postman_tutorial.rst
@@ -48,11 +48,13 @@ Using Postman
     .. image:: ../images/postman_tutorial_variables.png
        :align: center
 
-#. Test the first request, metadata, as seen below by clicking "Send". This will return the server Capability Statement.
+#. Test the first request, metadata, as seen below by clicking "Send".
 
     .. image:: ../images/postman_tutorial_metadata.png
        :align: center    
 
+#.  This will return the server Capability Statement:
+   
     ::
 
         {

--- a/index.rst
+++ b/index.rst
@@ -6,6 +6,7 @@ Firely Server is the answer to the growing need for a stable server that can be 
 
 .. image:: ./images/firelyserver_home.png
   :align: center
+  :width: 760px
 
 On these pages we provide you with the documentation you need to get up and running with your own standard Firely Server
 installation, as well as information on how to contact us when you have additional needs, such as a custom implementation

--- a/setting_up_firely_server/deployment/azureWebApp.rst
+++ b/setting_up_firely_server/deployment/azureWebApp.rst
@@ -25,6 +25,7 @@ Deployment
 
    .. image:: ../../images/Azure_02_ChooseName.png
       :align: center
+      :width: 760px
 
 #. Add the trial license file (firelyserver-trial-license.json) to the firely-server-latest.zip by dragging the license file into the zipfile.
 #. Open a webbrowser, navigate to ``https://<webapp>.scm.azurewebsites.net/ZipDeployUI`` and drag vonk_distribution.zip into the browser window. 
@@ -35,6 +36,7 @@ Deployment
    
    .. image:: ../../images/Azure_05_WebRoot.png
       :align: center
+      :width: 900px
    
 #. Open a browser and go to the site ``https://<webapp>.azurewebsites.net/`` . This will show the Firely Server home page.
 
@@ -46,6 +48,7 @@ with the settings for either :ref:`SQL Server<configure_sql>` or :ref:`MongoDB<c
 
 .. image:: ../../images/Azure_04_Settings.png
    :align: center
+   :width: 900px
 
 More information
 ----------------


### PR DESCRIPTION
adjusted stylesheet css for better scaling and set several images to have a max width. Also added a readthedocs.yaml for the upcoming change described here: https://blog.readthedocs.com/migrate-configuration-v2/ 
Marten and I will test on August 14 if no issues in the readthedocs builds occur during the brownout described in the blogpost.
Currently also adjusting scaling in docs for Forge, FT, Simplifier, and SDK