### PR TITLE
Added info AllowedProfiles section+adjustments

### DIFF
--- a/features_and_tools/restful_api.rst
+++ b/features_and_tools/restful_api.rst
@@ -17,8 +17,7 @@ Create, read, update, patch, delete
 -----------------------------------
 
 These five operations to manage the contents of the Firely Server, commonly referenced by the acronym CRUD, are implemented as per the specification. Patch is implemented as `FHIR Patch <http://hl7.org/fhir/fhirpatch.html>`_, as this is the most versatile one.
-This includes version-read and the conditional variations. 
-Only a few limitations apply.
+A few limitations apply.
 
 Firely Server enables create-on-update: If you request an update and no resource exists for the given id, the provided resource will be created under the provided id.
 
@@ -55,7 +54,7 @@ Limitations on CRUD
 
 #. It is not possible to bring a resource that has earlier been deleted back to life with a conditional update while providing the logical id of the resource in the request payload. This operation will result in an ``HTTP 409 Conflict`` error. As a workaround, it is possible to create a new resource (with a new logical id) by omitting the ``id`` field in the payload.
 #. Parameter ``_pretty`` is not yet supported.
-#. XML Patch and JSON Patch are not supported.
+#. XML Patch and JSON Patch, as well as version-read and conditional variations of FHIR Patch are not yet supported.
 
 .. _restful_versioning:
 

--- a/setting_up_firely_server/configuration/appsettings.rst
+++ b/setting_up_firely_server/configuration/appsettings.rst
@@ -562,13 +562,14 @@ See :ref:`feature_patienteverything`.
 .. _uri_conversion:
 Uri conversion on import and export
 -----------------------------------
+
 Upon importing, Firely Server converts all references expresssed as absolute URIs with the root corresponding to the server URL.
-For example, `` "reference": "https://someHost/fhir/Patient/someId" `` will be stored as   `` "reference": "Patient/someId" `` .
+For example, ``"reference": "https://someHost/fhir/Patient/someId"`` will be stored as   ``"reference": "Patient/someId"``.
 Similarly,  upon exporting, the references stored as relative URIs will be converted back to an absolute URI by adding the 
 root server location to the relative URI.
 
-In addition, any element of type `` url `` or `` uri `` can also be converted upon import or export, as long as the FHIR path 
-corresponding to the element in the FHIR resource are listed in the setting `` UrlMapping `` :
+In addition, any element of type ``url`` or ``uri`` can also be converted upon import or export, as long as the FHIR path 
+corresponding to the element in the FHIR resource are listed in the setting ``UrlMapping`` :
 
 ::
 

--- a/setting_up_firely_server/configuration/prevalidation.rst
+++ b/setting_up_firely_server/configuration/prevalidation.rst
@@ -58,3 +58,17 @@ When you add canonical urls of StructureDefinitions to this list, Firely Server 
 So in the example above, Firely Server will only allow resources that conform to either the DAF Patient profile or the DAF AllergyIntolerance profile.
 
 Note that the resource has to declare conformance to the profile in its ``meta.profile`` element. Firely Server will *not* try to validate a resource against all the ``Validation.AllowedProfiles`` to see whether the resource conforms to any of them, only those that the resource claims conformance to.
+
+Also note that if you have enabled AuditEvent logging and/or generate AuditEvent Signatures, an AuditEvent and/or Provenance resource will be generated when you enter resources in Firely Server.
+These AuditEvent and Provenance resources will also be checked against the AllowedProfiles section. It is therefore necessary to add the hl7 core profiles of these resources to the AllowedProfiles section, otherwise they will fail to be saved in the database.
+::
+  {
+    "Validation": {
+      ...
+      "AllowedProfiles": [
+        "http://hl7.org/fhir/StructureDefinition/AuditEvent",
+        "http://hl7.org/fhir/StructureDefinition/Provenance"
+        ...
+      ]
+    }
+  }

--- a/setting_up_firely_server/configuration/prevalidation.rst
+++ b/setting_up_firely_server/configuration/prevalidation.rst
@@ -60,7 +60,7 @@ So in the example above, Firely Server will only allow resources that conform to
 Note that the resource has to declare conformance to the profile in its ``meta.profile`` element. Firely Server will *not* try to validate a resource against all the ``Validation.AllowedProfiles`` to see whether the resource conforms to any of them, only those that the resource claims conformance to.
 
 Also note that if you have enabled AuditEvent logging and/or generate AuditEvent Signatures, an AuditEvent and/or Provenance resource will be generated when you enter resources in Firely Server.
-These AuditEvent and Provenance resources will also be checked against the AllowedProfiles section. It is therefore necessary to add the hl7 core profiles of these resources to the AllowedProfiles section, otherwise they will fail to be saved in the database.
+These AuditEvent and Provenance resources will also be checked against the AllowedProfiles section. It is therefore necessary to add the HL7 core canonicals of these resources to the AllowedProfiles section, otherwise they will fail to be saved in the database.
 ::
   {
     "Validation": {


### PR DESCRIPTION
- Added information on the need to AuditEvents and Provenance core profiles in AllowedProfiles section.
- Made some adjustments in the URI conversion section as parts here were not rendered correctly
- Made adjustments for VONK-5420, to clarify that we do not support version specific or conditional FHIR Patch