### PR TITLE
Reapply "feature: VONK-5735: multi-tenancy"

### DIFF
--- a/features_and_tools/features.rst
+++ b/features_and_tools/features.rst
@@ -25,7 +25,9 @@ Firely Server offers many features as defined in the FHIR Specification and beyo
    x-provenance
    openapi
    pubsub
+   multi-tenancy
    features-availability
+   
 
 
   

--- a/features_and_tools/firely-server-ingest.rst
+++ b/features_and_tools/firely-server-ingest.rst
@@ -40,6 +40,7 @@ General usage
 
   * Firely Server instances targeting the same database will be impacted severely by the workload that FSI puts on the database. We advise to stop the Firely Server instances while the import is performed.
   * Only one instance of FSI per database should be run at a time. FSI can utilize all the cores on the machine it is run on, and insert data over several connections to the database in parallel. Multiple instances would probably cause congestion in the database.
+  * FSI does not add tenant security labels, see :ref:`feature_multitenancy`.
 
 Prerequisites
 ^^^^^^^^^^^^^

--- a/features_and_tools/multi-tenancy.rst
+++ b/features_and_tools/multi-tenancy.rst
@@ -1,0 +1,60 @@
+.. _feature_multitenancy:
+
+Multi-tenancy
+=============
+
+Firely Server offers *virtual* multi-tenancy. All the resources are still stored in a single database, but by applying tenant information they are virtually separated.
+The basics are simple:
+
+- On every request, the tenant is read from either a specific HTTP header or a claim in the authorization token.
+- If the request creates or updates any resource, the tenant is applied to each of those resources. This is done by adding a *security label* to the ``meta.security`` element of the resource.
+- For both reading and writing resources, the tenant is used to limit access to only the resources having a matching security label.
+- Upon reading, the tenant security label is removed from the resource and thus not visible from the outside.
+
+Implications
+------------
+
+.. warning:: 
+
+    It is very difficult to enable this feature after resources have already been loaded into Firely Server. 
+    Resources that do not have a tenant security label cannot be retrieved or updated anymore.
+
+.. warning:: 
+
+    :ref:`Firely Server Ingest <tool_fsi>` does not apply tenant labels. You must add them to any resource before ingesting them. 
+    This includes Bundle entries.
+
+Other implications:
+
+- The logical id of a resource must be unique *across tenants*.
+- An update cannot change the tenant of a resource.
+- If a security label for the tenant is applied already in the body of the request, it must be consistent with the tenant in the request.
+- Handling the tenant information takes time and resources, and may increase the response time.
+
+Configuration
+-------------
+
+To enable the feature, include ``Vonk.Plugin.VirtualTenants`` in the pipeline for the regular resources (typically the ``"/"`` path).
+
+You can control the working of the feature with the settings:
+
+    .. code-block:: jsonc
+
+        "VirtualTenants": { 
+            "TenantHeader": "x-firely-tenant",
+            "TenantClaim": "tenant",
+            "TenantLabelSystem": "http://server.fire.ly/fhir/sid/tenant-label",
+            "AllowTenantFromHeader": true,
+            "AllowTenantFromClaim": true
+        },
+
+:TenantHeader: The name of the HTTP header to read the tenant from. This is only evaluated if ``AllowTenantFromHeader`` is set to ``true``.
+:TenantClaim: The name of the claim in the authorization token to read the tenant from. This is only evaluated if ``AllowTenantFromClaim`` is set to ``true``.
+:TenantLabelSystem: The value of the ``meta.security.system`` element to use for the tenant security label. You can only choose this once.
+:AllowTenantFromHeader: The tenant may be specified with an HTTP header, with the name specified in ``TenantHeader``.
+:AllowTenantFromClaim: The tenant may be specified with a claim in the authorization token, with the name specified in ``TenantClaim``.
+
+.. warning:: 
+
+    Choose the ``TenantLabelSystem`` wisely. Once resources have been loaded into Firely Server it is nearly impossible to update this.
+


### PR DESCRIPTION
This reverts commit 543669e077569daece182cc6a83fcea370fa6981.

The previous release note for this feature is excluded. Please add it when releasing the next version of Firely Server 