### PR TITLE
fix: MongoDB auth - markup (code blocks were not rendered)

### DIFF
--- a/setting_up_firely_server/configuration/mongodb/db_mongo_auth.rst
+++ b/setting_up_firely_server/configuration/mongodb/db_mongo_auth.rst
@@ -181,11 +181,11 @@ User accounts for the Data database
 User accounts for the Administration database
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-These accounts are only needed if you run the :ref:`Administration database on MongoDB <configure_mongodb_admi>`. By default Firely Server uses SQLite for the Administration database.
+These accounts are only needed if you run the :ref:`Administration database on MongoDB <configure_mongodb_admin>`. By default Firely Server uses SQLite for the Administration database.
 
 We assume ``fs_admin`` as the name of the database.
 
-.. code-block::javascript
+.. code-block:: javascript
 
     print("dropping fs_admin users and roles")
     if (userExists("fs_admin", "fs_admin_user"))
@@ -277,7 +277,9 @@ Enable access control on MongoDB
 
 Access control is enabled in different ways depending on the hosting platform. See the `MongoDB documentation <https://www.mongodb.com/docs/manual/tutorial/enable-authentication/>`_ on this.
 In short, for MongoDB Atlas access control is mandatory and cannot be disabled. For MongoDB Enterprise or Community it can be enabled by the paramater ``--auth`` to the ``mongod`` command.
-When running it in a Docker container, you can add this parameter by changing the ``command`` in your compose.yaml::
+When running it in a Docker container, you can add this parameter by changing the ``command`` in your compose.yaml
+
+.. code-block:: yaml
 
     services:
       mongodb_latest:
@@ -296,20 +298,22 @@ ConnectionStrings
 
 Once access control is enabled, you have to configure the user and password in the connectionstring. The connectionstrings below serve as a template, using ``localhost`` as the host. Replace this with the correct hostname for your environment.
 
-.. note:: 
-    The roles and users above differentiate between the authorization needed to perform an automatic upgrade, and the authorization needed for regular operation of Firely Server. It is possible to configure separate connection strings for these two roles and this can be done for both the administration database and the regular repository database.
-    You may use the `fs_data_upgrade_user` in the `AutoUpdateConnectionString` field that will be used only when performing an upgrade of the MongoDb schemas, and the `fs_data_user` in the regular `ConnectionString` field for normal use. If `AutoUpdateConnectionString` is not set, the `ConnectionString` will be used in both cases.
-    .. code-block::json
-    "MongoDbOptions": {  
-        "ConnectionString": "mongodb://fs_data_user:fs_data_secret@localhost:27017/vonkdata?authSource=fs_data",  
-        "EntryCollection": "vonkentries",  
-        "MaxLogLine": 300,  
-        "AutoUpdateConnectionString" : "mongodb://fs_data_upgrade_user:fs_data_upgrade_secret@localhost:27017/vonkdata?authSource=fs_data"
-    }
-    // same for administration database
-
 #. Data database: ``mongodb://fs_data_upgrade_user:fs_data_upgrade_secret@localhost/fs_data?authSource=fs_data``
 #. Administration database: ``mongodb://fs_admin_upgrade_user:fs_admin_upgrade_secret@localhost/fs_admin?authSource=fs_admin``
+
+.. note:: 
+    The roles and users above differentiate between the authorization needed to perform an automatic upgrade, and the authorization needed for regular operation of Firely Server. It is possible to configure separate connection strings for these two roles and this can be done for both the administration database and the regular repository database.
+    You may use the ``fs_data_upgrade_user`` in the ``AutoUpdateConnectionString`` field that will be used only when performing an upgrade of the MongoDb schemas, and the ``fs_data_user`` in the regular ``ConnectionString`` field for normal use. If ``AutoUpdateConnectionString`` is not set, the ``ConnectionString`` will be used in both cases.
+
+    .. code-block:: json
+
+        "MongoDbOptions": {  
+            "ConnectionString": "mongodb://fs_data_user:fs_data_secret@localhost:27017/vonkdata?authSource=fs_data",  
+            "EntryCollection": "vonkentries",  
+            "MaxLogLine": 300,  
+            "AutoUpdateConnectionString" : "mongodb://fs_data_upgrade_user:fs_data_upgrade_secret@localhost:27017/vonkdata?authSource=fs_data"
+        }
+        // same for administration database
 
 .. note:: 
 


### PR DESCRIPTION
Some code blocks were not rendered due to a missing whitespace before the language moniker, and missing empty line between the `.. code-block` and the actual code.

Also several inline code markups had single backticks instead of double.