### PR TITLE
Fix us core6 link label

### DIFF
--- a/compliance/igs.rst
+++ b/compliance/igs.rst
@@ -147,7 +147,7 @@ In summary, the USCDI defines the core health data elements for nationwide inter
      - * `hl7.fhir.us.core|3.1.1 <https://registry.fhir.org/package/hl7.fhir.us.core|3.1.1>`_
        * `hl7.fhir.us.core|4.0.0 <https://registry.fhir.org/package/hl7.fhir.us.core|4.0.0>`_
        * `hl7.fhir.us.core|5.0.1 <https://registry.fhir.org/package/hl7.fhir.us.core|5.0.1>`_
-       * `hl7.fhir.us.core|5.0.1 <https://registry.fhir.org/package/hl7.fhir.us.core|6.1.0>`_
+       * `hl7.fhir.us.core|6.0.1 <https://registry.fhir.org/package/hl7.fhir.us.core|6.1.0>`_
 
 Known Limitations
 -----------------


### PR DESCRIPTION
Just updated the label for the US Core 6 link.