### PR TITLE
Minor formatting fixes, references and typos.

### DIFF
--- a/facade/databasemodel.rst
+++ b/facade/databasemodel.rst
@@ -85,7 +85,7 @@ Create your first mapping
 -------------------------
 
 #. Add a new ``public`` class ``ResourceMapper`` to the project
-#. Add usings for ``Vonk.Core.Common``, for ``Hl7.Fhir.Model``, for ``Hl7.Fhir.Support`` and for ``<your project>.Models``
+#. Add usings for ``Vonk.Core.Common``, for ``Hl7.Fhir.Model``, for ``Hl7.Fhir.Support``, for ``Vonk.Fhir.R4`` and for ``<your project>.Models``
 #. Add a method to the class ``public IResource MapPatient(ViSiPatient source)``
 #. In this method, put code to create a FHIR Patient object, and fill its elements with data from the ViSiPatient:
 
@@ -100,7 +100,7 @@ Create your first mapping
                                            source.PatientNumber));
      // etc.
 
-  For more examples of filling the elements, see the FHIR API documentation: `FHIR-model <https://docs.fire.ly/projects/Firely-NET-SDK/model.html>`_.
+  For more examples of filling the elements, see the FHIR API documentation: `FHIR-model <https://docs.fire.ly/projects/Firely-NET-SDK/en/latest/model.html>`_.
 
 5. Then return the created Patient object as an IResource with ``patient.ToIResource()``.
 

--- a/facade/enablechange_1.rst
+++ b/facade/enablechange_1.rst
@@ -210,5 +210,3 @@ The end?
 --------
 
 This concludes the second exercise. Please feel free to try out more options, and :ref:`ask for help <vonk-contact>` if you get stuck!
-
-The next topic will show you how to integrate :ref:`Access Control<feature_accesscontrol>`.

--- a/security/tokens_and_compartments.rst
+++ b/security/tokens_and_compartments.rst
@@ -124,7 +124,7 @@ In this paragraph we will explain how access control decisions are made for the 
 
       :Request: ``GET [base]/Patient?name=fred``
       :Type-Access: User must have read access to Patient, otherwise HTTP Status Code 403 is returned. 
-      :Compartment: If a Patient Compartment is active, the Filter from it will be added to the search, e.g. ``GET [base]/Patient?name=fred&identifier=123``
+      :Compartment: If a Patient Compartment is active, the filter from it will be added to the search, e.g. ``GET [base]/Patient?name=fred&identifier=123``
 
    #. Search on type related to compartment
 

--- a/setting_up_firely_server/configuration/plugins/available_plugins.rst
+++ b/setting_up_firely_server/configuration/plugins/available_plugins.rst
@@ -167,11 +167,15 @@ Support for different FHIR versions
 :Order: 100
 :Description: Registers services to support FHIR STU3 (or R3).
 
+.. _vonk_plugins_fhir_r3_specification:
+
 :Name: FHIR R3 Specification
 :Configuration: ``Vonk.Fhir.R3.FhirR3SpecificationConfiguration``
 :License token: http://fire.ly/vonk/plugins/fhirr3
 :Order: 112
 :Description: Registers an ``Hl7.Fhir.Specification.IStructureDefinitionSummaryProvider`` for FHIR STU3 (or R3).
+
+.. _vonk_plugins_fhir_r3_validation:
 
 :Name: FHIR R3 Validation
 :Configuration: ``Vonk.Fhir.R3.Validation.ValidationConfigurationR3``
@@ -187,11 +191,15 @@ Support for different FHIR versions
 :Order: 101
 :Description: Registers services to support FHIR R4.
 
+.. _vonk_plugins_fhir_r4_specification:
+
 :Name: FHIR R4 Specification
 :Configuration: ``Vonk.Fhir.R4.FhirR4SpecificationConfiguration``
 :License token: http://fire.ly/vonk/plugins/fhirr4
 :Order: 112
 :Description: Registers an ``Hl7.Fhir.Specification.IStructureDefinitionSummaryProvider`` for FHIR R4.
+
+.. _vonk_plugins_fhir_r4_validation:
 
 :Name: FHIR R4 Validation
 :Configuration: ``Vonk.Fhir.R4.Validation.ValidationConfigurationR4``
@@ -257,6 +265,8 @@ FHIR RESTful interactions
    * ``BundleOptions``, see :ref:`bundle_options`, for number of returned results
    
    See :ref:`vonk_reference_api_isearchrepository` and :ref:`vonk_facade`.
+
+.. _vonk_plugins_search_repository:
 
 :Name: Search support
 :Configuration: ``Vonk.Core.Repository.RepositorySearchSupportConfiguration``
@@ -396,11 +406,15 @@ FHIR RESTful interactions
 :Order: 5180
 :Description: Implements FHIR $meta on instance level.
 
+.. _vonk_plugins_meta_add_configuration:
+
 :Name: Meta Add
 :Configuration: ``Vonk.Core.Operations.MetaOperation.MetaAddConfiguration``
 :License token: http://fire.ly/vonk/plugins/meta
 :Order: 5190
 :Description: Implements FHIR $meta-add on instance level.
+
+.. _vonk_plugins_meta_delete_configuration:
 
 :Name: Meta Delete
 :Configuration: ``Vonk.Core.Operations.MetaOperation.MetaDeleteConfiguration``
@@ -546,11 +560,15 @@ Auditing
 :Order: 2010
 :Description: Makes the user id and name from the JWT token (if present) available for logging. See :ref:`feature_auditing` for more info.
 
+.. _vonk_plugins_audit_transaction_configuration:
+
 :Name: Audit logging for transactions
 :Configuration: ``Vonk.Plugin.Audit.AuditTransactionConfiguration``
 :License token: http://fire.ly/vonk/plugins/audit
 :Order: 3100
 :Description: Logs requests and responses for transactions to a file. See :ref:`feature_auditing` for more info.
+
+.. _vonk_plugins_audit_configuration:
 
 :Name: Audit log
 :Configuration: ``Vonk.Plugin.Audit.AuditConfiguration``
@@ -558,11 +576,15 @@ Auditing
 :Order: 3150
 :Description: Logs requests and responses to a file. See :ref:`feature_auditing` for more info.
 
+.. _vonk_plugins_audit_event_transaction_configuration:
+
 :Name: AuditEvent logging for transactions
 :Configuration: ``Vonk.Plugin.Audit.AuditEventTransactionConfiguration``
 :License token: http://fire.ly/vonk/plugins/audit
 :Order: 3105
 :Description: Logs requests and responses for transactions to the database. See :ref:`feature_auditing` for more info.
+
+.. _vonk_plugins_audit_event_configuration:
 
 :Name: AuditEvent logging
 :Configuration: ``Vonk.Plugin.Audit.AuditEventConfiguration``
@@ -727,11 +749,15 @@ Administration API
 :Order: 1160
 :Description: Sets up a sequence of plugins for the Administration API. Administration API is different from general plugins since it branches off of the regular processing pipeline and sets up a second pipeline for the /administration endpoint.
 
+.. _vonk_plugins_administration_stu3_services:
+
 :Name: Fhir STU3 Administration services
 :Configuration: ``Vonk.Administration.FhirR3.RepositoryConfigurationR3``
 :license token: http://fire.ly/vonk/plugins/administration/fhirr3
 :Order: 4310
 :Description: Implements support services to work with FHIR STU3 conformance resources in the Administration API.
+
+.. _vonk_plugins_administration_r4_services:
 
 :Name: Fhir R4 Administration services
 :Configuration: ``Vonk.Administration.FhirR4.RepositoryConfigurationR4``
@@ -748,17 +774,23 @@ Bulk Data
 :Order: 5003
 :Description: Support for system-level ``$export`` operation. See :ref:`feature_bulkdataexport`.
 
+.. _vonk_plugins_group_bulk_data_export:
+
 :Name: Group Bulk Data Export
 :Configuration: ``Vonk.Plugin.BulkDataExport.GroupBulkDataExportConfiguration``
 :license token: ``http://fire.ly/vonk/plugins/bulk-data-export``
 :Order: 5004
 :Description: Support for instance-level ``$export`` operation. See :ref:`feature_bulkdataexport`.
 
+.. _vonk_plugins_patient_bulk_data_export:
+
 :Name: Patient Bulk Data Export
 :Configuration: ``Vonk.Plugin.BulkDataExport.PatientBulkDataExportConfiguration``
 :license token: ``http://fire.ly/vonk/plugins/bulk-data-export``
 :Order: 5005
 :Description: Support for type-level ``$export`` operation. See :ref:`feature_bulkdataexport`.
+
+.. _vonk_plugins_patient_everything_data_export:
 
 :Name: Patient everything
 :Configuration: ``Vonk.Plugin.PatientEverything``


### PR DESCRIPTION
Three minor changes:
(1) added paragraph references in available_plugins to add new lines, as plugins are otherwise all joined together and it's hard to read through them
(2) removed "next topic" in the facade plugin tutorial, as the access control referenced there is actually one of the previous chapters
(3) added requirement to add "usings" for Vonk.Fhir.R4 in the databasemodel.rst, as otherwise the step 5: patient.ToIResource() doesn't work