### PR TITLE
Update ToIResource() usage examples

### DIFF
--- a/reference/programming_api/bundles.rst
+++ b/reference/programming_api/bundles.rst
@@ -135,6 +135,10 @@ Using all this to turn the ``SearchResult`` returned from the ``ISearchRepositor
 
 .. code-block:: csharp
 
+      using Vonk.Fhir.R4;
+
+      ...
+
       var bundle = searchResult
             .ToSearchBundle(SearchMode.match, vonkContext.InformationModel)
             //informationModel is needed because bundle has slight differences between STU3 and R4

--- a/reference/programming_api/iresource.rst
+++ b/reference/programming_api/iresource.rst
@@ -63,12 +63,12 @@ IResource
         IEnumerable<IResource> ContainedResources { get; }
    }
 
-If you work with a POCO, you can use the extension method ToIResource(string informationModel) from Vonk.Fhir.R4 to adapt it to an IResource:
+If you work with a POCO, you can use an extension method ToIResource() from a FHIR version namespace, such as Vonk.Fhir.R4, to adapt it to an IResource:
 
 .. code-block:: csharp
 
    var patientPoco = new Patient(); //Requires Hl7.Fhir.Model
-   var resource = patientPoco.ToIResource(VonkConstants.Model.FhirR4);
+   var resource = patientPoco.ToIResource(); //Requires a version namespace like Vonk.Fhir.R4
 
 IResource is immutable, so changes will always result in a new instance. Changes can usually be applied with extension methods on ISourceNode, found in :ref:`Vonk.Core.ElementModel.ISourceNodeExtensions <vonk_reference_api_elementmodel>`. There are also several extension methods specifically for IResource in Vonk.Core.Common.IResourceExtensions:
 

--- a/reference/programming_api/iresource.rst
+++ b/reference/programming_api/iresource.rst
@@ -63,7 +63,7 @@ IResource
         IEnumerable<IResource> ContainedResources { get; }
    }
 
-If you work with a POCO, you can use the extension method ToIResource(string informationModel) from Vonk.Core to adapt it to an IResource:
+If you work with a POCO, you can use the extension method ToIResource(string informationModel) from Vonk.Fhir.R4 to adapt it to an IResource:
 
 .. code-block:: csharp
 

--- a/reference/programming_api/vonkcontext.rst
+++ b/reference/programming_api/vonkcontext.rst
@@ -147,6 +147,10 @@ If you want to **change** the payload, assign a whole new one. Generally you wou
 
 .. code-block:: csharp
 
+   using Vonk.Fhir.R4;
+
+   ...
+
    if (request.TryGetPayload(response, out var resource)
    {
       //Explicit typing of variables for clarity, normally you would use 'var'.


### PR DESCRIPTION
`ToIResource()` was moved from `Vonk.Core`