### PR TITLE
Update documentation for Firely Server features and configurations VONK-8059 and VONK-8051

### DIFF
--- a/features_and_tools/custom_operations/documentoperation.rst
+++ b/features_and_tools/custom_operations/documentoperation.rst
@@ -15,7 +15,7 @@ $document is implemented on the Composition endpoint of Firely Server. Typically
 
 .. code-block:: HTTP
 
-    POST {base-url}/Composition
+    POST {base-url}/Composition/$document
 
 .. code-block:: json
 
@@ -24,7 +24,7 @@ $document is implemented on the Composition endpoint of Firely Server. Typically
         "parameter": [
             {
                 "name": "id",
-                "valueString": "example"
+                "valueString": "<id of the composition resource>"
             }
         ]
     }
@@ -41,7 +41,7 @@ The generated Document bundle can be immediately stored on the Bundle endpoint o
 
 .. code-block:: HTTP
 
-    POST {base-url}/Composition
+    POST {base-url}/Composition/$document
 
 .. code-block:: json
 
@@ -50,7 +50,7 @@ The generated Document bundle can be immediately stored on the Bundle endpoint o
         "parameter": [
             {
                 "name": "id",
-                "valueString": "example"
+                "valueString": "<id of the composition resource>"
             },
             {
                 "name": "persist",
@@ -63,7 +63,7 @@ or
 
 .. code-block:: HTTP
 
-    GET {base-url}/Composition/<id>?persist=true
+    GET {base-url}/Composition/<id>/$document?persist=true
 
 Known limitations
 -----------------

--- a/features_and_tools/restful_api.rst
+++ b/features_and_tools/restful_api.rst
@@ -188,7 +188,7 @@ Navigational paging links
 Paging behavior of Firely Server can be configured in the ``BundleOptions`` of the appsettings, also see :ref:`bundle_options`. ::
     
   "BundleOptions": {
-    "DefaultTotal": "accurate", // none, accurate
+    "DefaultTotal": "none", // none, accurate
     "DefaultCount": 10,
     "MaxCount": 50,
     "DefaultSort": "-_lastUpdated"

--- a/features_and_tools/restful_api.rst
+++ b/features_and_tools/restful_api.rst
@@ -149,7 +149,7 @@ In the example below an OperationOutcome for a No-Op scenario is returned when t
 Versioning
 ----------
 
-Firely Server keeps a full version history of every resource, including the resources on the :ref:`administration_api`.
+Firely Server keeps a full version history of every resource, including the resources on the :ref:`administration_api`. Be aware that version specific searches cannot be used when SMART on FHIR is enabled in Firely Server version 5.11.0 and later versions.
 
 .. _restful_search:
 
@@ -181,9 +181,41 @@ Firely Server also supports ``_include:iterate`` and ``_revinclude:iterate``, as
 
 .. _navigational_links:
 
-Navigational links
-^^^^^^^^^^^^^^^^^^
-The "next", "prev", and "last" link may contain privacy-sensitive information as part of a search parameter value. In order to not expose these values in logs, the :ref:`Vonk.Plugin.SearchAnonymization<vonk_plugins_searchAnonymization>` plugin can be used. It will replace the query parameter part of the navigational link with an opaque UUID. The plugin must be used starting with FHIR R5 as the specification mandates the removal of sensitive information.
+Navigational paging links
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. warning:: Please be aware that setting the ``DefaultTotal`` to "accurate" may have a performance impact on the server, as additional queries need to be made to calculate this number.
+
+Paging behavior of Firely Server can be configured in the ``BundleOptions`` of the appsettings, also see :ref:`bundle_options`. ::
+    
+  "BundleOptions": {
+    "DefaultTotal": "accurate", // none, accurate
+    "DefaultCount": 10,
+    "MaxCount": 50,
+    "DefaultSort": "-_lastUpdated"
+  },
+  
+
+If ``DefaultTotal`` is set to "none" the server will return:
+
+* The ``self`` and ``next`` links in the bundle response on the first page
+* Additionally, the ``first`` and ``prev`` links are returned on subsequent pages
+* The ``self``, ``first``, and ``prev`` links are returned on the last page
+
+If ``DefaultTotal`` is set to "accurate" the server will additionally return a ``last`` link on all but the last page, as well as a ``total`` element in the bundle response. The ``total`` element contains the total number of resources that match the search criteria.
+With ``DefaultCount``, the number of resources that are returned per page can be regulated. The maximum number of resources that can be returned per page is set with ``MaxCount``. The default sort order can be set with ``DefaultSort``.
+
+If MongoDb is configured as the repository back-end, Firely Server may utilize keyset pagination for navigating through the search results for optimized performance. There are a few limitations to this feature:
+
+* It is only implemented for repositories with MongoDb as a database back-end, and not for SQL Server or SQLite.
+* It is only applied if ``_sort=-_lastUpdated`` or if ``_sort`` is not set by default and not provided in the query request
+* It is only applied if no resource specific search parameters are used in the query request
+* It cannot be used in combination with the ``_skip`` parameter
+* The result set will not contain a ``last`` link
+
+If keyset pagination is applied, the navigational links will only contain ``first``, ``self`` and ``next`` links, with the ``first`` link missing on the first page and the last page not containing a ``next`` link. These links will not contain the ``_skip`` parameter but instead have a ``_continuationToken`` that can be used to retrieve the next results page.
+
+The ``next``, ``prev``, and ``last`` link may contain privacy-sensitive information as part of a search parameter value. In order to not expose these values in logs, the :ref:`Vonk.Plugin.SearchAnonymization<vonk_plugins_searchAnonymization>` plugin can be used. It will replace the query parameter part of the navigational link with an opaque UUID. The plugin must be used starting with FHIR R5 as the specification mandates the removal of sensitive information.
+
 
 Modifiers
 ^^^^^^^^^
@@ -361,6 +393,7 @@ Limitations on history
 
 #. ``_at`` parameter is not yet supported.
 #. Paging is supported, but it is not isolated from intermediate changes to resources.
+#. In Firely Server version 5.11.0 and later versions ``_history`` cannot be used when SMART on FHIR is enabled.
 
 .. _restful_batch:
 

--- a/security/smart.rst
+++ b/security/smart.rst
@@ -2,6 +2,9 @@
 
 SMART on FHIR Configuration
 ===========================
+.. warning::
+
+  In Firely Server version 5.11.0 and later versions ``vread`` and ``_history`` searches will be disabled when SMART on FHIR is enabled. 
 
 .. note::
 

--- a/setting_up_firely_server/configuration/appsettings.rst
+++ b/setting_up_firely_server/configuration/appsettings.rst
@@ -376,7 +376,8 @@ Search size
     },
 
 
-The Search interactions returns a bundle with results. Users can specify the number of results that they want to receive in one response with the ``_count`` parameter.
+The Search interactions returns a bundle with results. Users can specify the number of results that they want to receive in one response with the ``_count`` parameter. Also see :ref:`_navigational_links` .
+
 
 * ``DefaultCount`` sets the number of results if the user has not specified a ``_count`` parameter.
 * ``MaxCount`` sets the number of results in case the user specifies a ``_count`` value higher than this maximum. This is to protect Firely Server from being overloaded.


### PR DESCRIPTION
- Updated docs on $document operation
- added info for keyset pagination (VONK-8059)
- added info for SoF in combination with history and vread (VONK-8051)