### PR TITLE
Improve custom SearchParam docs

### DIFF
--- a/features_and_tools/customsearchparameters.rst
+++ b/features_and_tools/customsearchparameters.rst
@@ -123,6 +123,66 @@ Besides that you can also control how many threads run in parallel to speed up t
 
 Use any integer value >= 1.
 
+.. _feature_customsp_add:
+
+Adding a New SearchParameter
+----------------------------
+
+Follow these steps to add a new `SearchParameter` to a running Firely Server instance:
+
+1. **Create the SearchParameter Resource**  
+   Define the `SearchParameter` resource in either JSON or XML format. Ensure that it includes the required fields such as `url`, `name`, `code`, `base`, and `expression`. For example:
+
+   .. code-block:: json
+
+      {
+        "resourceType": "SearchParameter",
+        "url": "http://example.org/fhir/SearchParameter/Patient-example",
+        "name": "example",
+        "status": "active",
+        "code": "example",
+        "base": ["Patient"],
+        "type": "string",
+        "expression": "Patient.name"
+      }
+
+2. **Post the SearchParameter to the Administration API**  
+   Use the Administration API to add the `SearchParameter` to Firely Server. Send a `POST` request to the following endpoint:
+
+   .. code-block:: bash
+
+      POST http(s)://<firely-server-endpoint>/administration/SearchParameter
+      Content-Type: application/fhir+json
+
+   Include the `SearchParameter` resource in the body of the request.
+
+3. **Re-index the Resources**  
+   After adding the `SearchParameter`, you need to re-index the resources in the database to ensure the new parameter is applied. Use the `$reindex` operation:
+
+   .. code-block:: bash
+
+      POST http(s)://<firely-server-endpoint>/administration/$reindex
+      Content-Type: application/x-www-form-urlencoded
+
+   In the body of the request, specify the `include` parameter with the name of the new `SearchParameter`:
+
+   .. code-block:: text
+
+      include=Patient.example
+
+4. **Verify the SearchParameter**  
+   Once the re-indexing is complete, verify that the new `SearchParameter` is working as expected by performing a search query using the parameter. For example:
+
+   .. code-block:: bash
+
+      GET http(s)://<firely-server-endpoint>/Patient?example=<value>
+
+5. **Monitor Logs and Results**  
+   Check the Firely Server logs for any errors or warnings during the process. Ensure that the search results match the expected behavior.
+
+.. note::
+   If you encounter any issues, ensure that the `SearchParameter` resource is valid and that the `expression` field correctly references the desired element in the FHIR resource.
+
 .. _feature_customsp_limitations:
 
 Limitations


### PR DESCRIPTION
Customers often forget how to create the SearchParams in FS.

I think that the docs make it difficult to read that. You have to read all about managing conformance resources while you only want to add a SearchParam. I think a step by step guide would be helpful here.