### PR TITLE
Fix Docker image name and container naming in docs

### DIFF
--- a/maintenance/metrics_dashboard.rst
+++ b/maintenance/metrics_dashboard.rst
@@ -74,11 +74,12 @@ Docker
 ^^^^^^
 
 1. Open your favorite command line tool and execute this command:
-   ``> docker pull firely/dashboard``
+   ``> docker pull firely/server-dashboard``
 
 2. Start the container (where FirelyServerUrl is the URL Firely Server runs on):
-   - in cmd.exe: ``docker run -d -p 7174:7174 -p 4317:4317 -e FirelyServerUrl="http://host.docker.internal:4080" --name firely/dashboard``
-   - in Powershell / Bash on macOS: ``docker run -d -p 7174:7174 -p 4317:4317 -e FirelyServerUrl='http://host.docker.internal:4080' --name firely/dashboard``
+   - in cmd.exe: ``docker run -d -p 7174:7174 -p 4317:4317 -e FirelyServerUrl="http://host.docker.internal:4080" --name firely-server-dashboard firely/server-dashboard``
+   - in Powershell / Bash on macOS: ``docker run -d -p 7174:7174 -p 4317:4317 -e FirelyServerUrl='http://host.docker.internal:4080' --name firely-server-dashboard firely/server-dashboard``
+
 
 3. Open a browser and use the address ``http://localhost:7174/``. This will show the landing page of Firely Server Dashboard. It does not show any data yet.
 


### PR DESCRIPTION
Fixed container name to reflect that it is firely/server-dashboard. Also adjusted container name references so that they did not contain forward slash (/).