### PR TITLE
doc: add setting WarnOnVersionMismatches

### DIFF
--- a/features_core_fhir_platform/restful_api.rst
+++ b/features_core_fhir_platform/restful_api.rst
@@ -167,6 +167,10 @@ are available. But Firely Server also allows :ref:`feature_customsp`.
 
 Chaining and reverse chaining is fully supported.
 
+Firely Server maintains the search index only for the current version of a resource. If your data contains versioned references (e.g. `Observation.subject` references `Patient/123/_history/2`), the search may match the current version of the referenced resource (e.g. `Patient/123/_history/5`), even if the reference is versioned.
+You can have a warning about this reported in the OperationOutcome of the search response by setting ``WarnOnVersionMismatches`` to true in the ``FhirCapabilities:SearchOptions`` configuration.
+Be aware though that this has a serious performance impact. Hence this warning is disabled by default.
+
 Quantity search on UCUM quantities automatically converts units to a canonical form. This means you can have kg in an Observation and search by lbs, or vice versa.
 
 `Compartment Search <http://www.hl7.org/implement/standards/fhir/search.html#2.21.1.2>`_ is supported.

--- a/releasenotes/releasenotes_v6.rst
+++ b/releasenotes/releasenotes_v6.rst
@@ -17,7 +17,7 @@ Improvements
 ^^^^^^^^^^^^
 
 #. Updated conformance cache configuration to ``ConformanceCache`` and added ``SlidingExpirationSeconds`` to control cache entry lifetime. This improves stability for scenarios that resolve or compile conformance resources over longer periods, such as CQL library dependency chains.
-
+#. Warning on version mismatches in chained queries are now optional, and by default disabled. See :ref:`restful_search`.
 
 .. _vonk_releasenotes_6_7_0:
 

--- a/setting_up_firely_server/appsettings_reference.rst
+++ b/setting_up_firely_server/appsettings_reference.rst
@@ -307,11 +307,12 @@ FHIR Capabilities
         //        "exp": "2099-12-31" // the expiration date of the key, this is a custom property and has to be added. Time will be ignored
         //    }
         //]
-      }
+      },
+      "WarnOnVersionMismatches": false
     }
   },
 
-See :ref:`restful_crud`.
+See :ref:`restful_crud` and :ref:`restful_search`.
 
 .. _disable_interactions:
 


### PR DESCRIPTION
This PR describes the new setting `FhirCapabilities:SearchOptions:WarnOnVersionMismatches`, introduced in VONK-9635.