### PR TITLE
Replace exhaustive dependency list with a stable SBOM reference (DEVOPS-811)

### DIFF
--- a/reference/dependencies.rst
+++ b/reference/dependencies.rst
@@ -9,10 +9,17 @@ with use in commercial, closed-source software.
 
 Rather than maintain a hand-written list here (which inevitably drifts out of sync with the actual dependency
 tree as packages are added, removed, or updated), Firely automatically generates a complete Software Bill of
-Materials (SBOM) - covering every direct and transitive dependency, for both the ZIP and Docker image
-distributions - as part of the build process for every release. Every dependency's license is checked
-automatically against that same compatibility policy. If you need the detailed SBOM for a specific release,
-please contact Firely support.
+Materials (SBOM) - covering every direct and transitive dependency - as part of the build process for every
+release. Every dependency's license is checked automatically against that same compatibility policy.
+
+You can retrieve the SBOM for a specific release yourself:
+
+* **Docker image**: the SBOM (and a build provenance attestation) is attached directly to the image. Retrieve
+  it with ``docker buildx imagetools inspect <image>:<tag> --format "{{ json .SBOM }}"``, or with
+  ``docker scout sbom <image>:<tag>`` if you have `Docker Scout <https://docs.docker.com/scout/>`_ available.
+* **ZIP**: published as a sibling file next to the release download on the
+  `download page <https://downloads.fire.ly/firely-server>`_, with a matching filename - for example,
+  ``firely-server-v6.9.0.zip`` and ``firely-server-v6.9.0.sbom.json``.
 
 .. _firely_oss_license:
 

--- a/reference/dependencies.rst
+++ b/reference/dependencies.rst
@@ -17,9 +17,16 @@ You can retrieve the SBOM for a specific release yourself:
 * **Docker image**: the SBOM (and a build provenance attestation) is attached directly to the image. Retrieve
   it with ``docker buildx imagetools inspect <image>:<tag> --format "{{ json .SBOM }}"``, or with
   ``docker scout sbom <image>:<tag>`` if you have `Docker Scout <https://docs.docker.com/scout/>`_ available.
-* **ZIP**: published as a sibling file next to the release download on the
-  `download page <https://downloads.fire.ly/firely-server>`_, with a matching filename - for example,
-  ``firely-server-v6.9.0.zip`` and ``firely-server-v6.9.0.sbom.json``.
+* **ZIP**: published as a sibling file next to the release download in the same public Azure Blob Storage
+  location, with a matching filename - for example, the latest release's ZIP and SBOM are at::
+
+      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/firely-server-latest.zip
+      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/firely-server-latest.sbom.json
+
+  and a specific version's (e.g. 6.9.0) at::
+
+      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/versions/firely-server-v6.9.0.zip
+      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/versions/firely-server-v6.9.0.sbom.json
 
 .. _firely_oss_license:
 

--- a/reference/dependencies.rst
+++ b/reference/dependencies.rst
@@ -3,61 +3,16 @@
 Dependencies of Firely Server and their licenses
 ================================================
 
-Firely Server is mainly built using libraries from Microsoft .Net Core and ASP.NET Core, along with a limited list of other libraries.
-This is the full list of direct depencies that Firely Server has on other libraries, along with their licenses.
+Firely Server is built on top of a wide range of open-source libraries - mainly from the .NET, ASP.NET Core,
+and MongoDB ecosystems - all under permissive licenses (MIT, Apache 2.0, BSD, and similar) that are compatible
+with use in commercial, closed-source software.
 
-This list uses the NuGet package names (or prefixes of them) so you can easily lookup further details of those packages on `NuGet.org <https://www.nuget.org>`_ if needed.
-
-#. Microsoft.AspNetCore.* - Apache 2.0
-#. Microsoft.ApplicationInsights.* - MIT
-#. Microsoft.Bcl.AsyncInterfaces - MIT
-#. Microsoft.EntityFrameworkCore.* - MIT
-#. Microsoft.Extensions.* - MIT
-#. Microsoft.AspNet.WebApi.Client - `MS-.NET-Library License <https://go.microsoft.com/fwlink/?LinkId=329770>`_
-#. System.Interactive.Async - MIT
-#. Microsoft.Data.SqlClient - MIT
-#. Microsoft.CSharp - MIT
-#. System.Interactive.Async - MIT
-#. System.Text.Json - MIT
-#. System.* - `MS-.NET-Library License <https://go.microsoft.com/fwlink/?LinkId=329770>`_
-#. NETStandard.Library - MIT
-#. NewtonSoft.Json - MIT
-#. IdentityModel.* - Apache 2.0
-#. IPNetwork2 - BSD 2-Clause "Simplified" License
-#. Serilog(.*) - Apache-2.0
-#. LinqKit.Microsoft.EntityFrameworkCore - MIT
-#. Hl7.Fhir.* - Firely OSS license (see below)
-#. Hl7.Cql.* - BSD 3-Clause License
-#. Fhir.Metrics - as Hl7.Fhir
-#. Simplifier.Licensing - as Hl7.Fhir
-#. Dapper - Apache 2.0
-#. SQLitePCLRaw.lib.e_sqlite3 - Apache 2.0
-#. SqlKata.* - MIT
-#. CreativeCode.JWS - MIT
-#. Azure.Storage.* - MIT
-#. MongoDB.* - Apache 2.0
-#. Duende.AccessTokenManagement - Apache-2.0
-
-Firely Server PubSub:
-
-#. MassTransit - Apache 2.0
-
-For in-house telemetry and statistics:
-
-#. OpenTelemetry.* - Apache 2.0
-#. MongoDB.Driver.Core.Extensions.DiagnosticSources - Apache 2.0
-#. InfluxDB.Client - MIT
-
-For unit testing:
-
-#. XUnit - Apache 2.0
-#. Moq - BSD 3
-#. FluentAssertions - Apache 2.0
-#. Microsoft.NETCore.Platforms - MIT
-#. Microsoft.NET.Test.Sdk - `MS-.NET-Library License <https://go.microsoft.com/fwlink/?LinkId=329770>`_
-#. System.Reactive - MIT
-#. coverlet.collector - MIT
-#. WireMock.Net - Apache 2.0
+Rather than maintain a hand-written list here (which inevitably drifts out of sync with the actual dependency
+tree as packages are added, removed, or updated), Firely automatically generates a complete Software Bill of
+Materials (SBOM) - covering every direct and transitive dependency, for both the ZIP and Docker image
+distributions - as part of the build process for every release. Every dependency's license is checked
+automatically against that same compatibility policy. If you need the detailed SBOM for a specific release,
+please contact Firely support.
 
 .. _firely_oss_license:
 

--- a/reference/dependencies.rst
+++ b/reference/dependencies.rst
@@ -17,15 +17,14 @@ You can retrieve the SBOM for a specific release yourself:
 * **Docker image**: the SBOM (and a build provenance attestation) is attached directly to the image. Retrieve
   it with ``docker buildx imagetools inspect <image>:<tag> --format "{{ json .SBOM }}"``, or with
   ``docker scout sbom <image>:<tag>`` if you have `Docker Scout <https://docs.docker.com/scout/>`_ available.
-* **ZIP**: published as a sibling file next to the release download in the same public Azure Blob Storage
-  location, with a matching filename - for example, the latest release's ZIP and SBOM are at::
+* **ZIP**: get the release itself from the `download page <https://downloads.fire.ly/firely-server>`_ as usual.
+  Its SBOM is published separately, at a URL matching the version you downloaded - for example, for the latest
+  release::
 
-      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/firely-server-latest.zip
       https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/firely-server-latest.sbom.json
 
-  and a specific version's (e.g. 6.9.0) at::
+  or for a specific version (e.g. 6.9.0)::
 
-      https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/versions/firely-server-v6.9.0.zip
       https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/versions/firely-server-v6.9.0.sbom.json
 
 .. _firely_oss_license:

--- a/reference/dependencies.rst
+++ b/reference/dependencies.rst
@@ -14,9 +14,6 @@ release. Every dependency's license is checked automatically against that same c
 
 You can retrieve the SBOM for a specific release yourself:
 
-* **Docker image**: the SBOM (and a build provenance attestation) is attached directly to the image. Retrieve
-  it with ``docker buildx imagetools inspect <image>:<tag> --format "{{ json .SBOM }}"``, or with
-  ``docker scout sbom <image>:<tag>`` if you have `Docker Scout <https://docs.docker.com/scout/>`_ available.
 * **ZIP**: get the release itself from the `download page <https://downloads.fire.ly/firely-server>`_ as usual.
   Its SBOM is published separately, at a URL matching the version you downloaded - for example, for the latest
   release::
@@ -26,6 +23,16 @@ You can retrieve the SBOM for a specific release yourself:
   or for a specific version (e.g. 6.9.0)::
 
       https://firelydownloads.blob.core.windows.net/firelyserver/firely-server/versions/firely-server-v6.9.0.sbom.json
+
+  This is available for all 5.x and 6.x releases, including versions published before this SBOM process existed.
+
+* **Docker image**: for releases published after this SBOM process was introduced (any release after 6.8.1), the
+  SBOM (and a build provenance attestation) is attached directly to the image. Retrieve it with
+  ``docker buildx imagetools inspect <image>:<tag> --format "{{ json .SBOM }}"``, or with
+  ``docker scout sbom <image>:<tag>`` if you have `Docker Scout <https://docs.docker.com/scout/>`_ available.
+  Unlike the ZIP, this isn't available for older image tags - attaching it to an already-published tag would
+  mean rebuilding and re-pushing it, which changes its digest, so we don't retrofit it onto images that have
+  already shipped.
 
 .. _firely_oss_license:
 


### PR DESCRIPTION
## What changed

Replaces the hand-maintained, per-package NuGet dependency/license list in `reference/dependencies.rst`
("Dependencies and licenses") with a short, stable summary plus concrete, verified SBOM retrieval instructions.

## Why

Follow-up from [DEVOPS-772](https://firely.atlassian.net/browse/DEVOPS-772) - see
[DEVOPS-811](https://firely.atlassian.net/browse/DEVOPS-811). The old list drifted out of sync with the actual
dependency tree (wildcard package-name prefixes, no versions, last touched 2025-07-02) and duplicated what
DEVOPS-772's automated SBOM/license check now covers accurately in CI for every release. One-time edit, not the
start of an automated recurring sync - see DEVOPS-772 for why that was considered and not chosen.

## Retrieval instructions, and why they're asymmetric between ZIP and Docker

- **ZIP**: get the release from the normal `download page <https://downloads.fire.ly/firely-server>`_; its SBOM
  is published separately at a predictable URL matching the version (confirmed via real, unauthenticated
  `curl` requests against the actual public blob storage - `firelydownloads.blob.core.windows.net/firelyserver`
  allows anonymous reads, including container listing). **Available for all 5.x/6.x releases** - a separate
  session backfilled `*.sbom.json` for every version from v5.0.0 through v6.8.1 plus
  `firely-server-latest.sbom.json`, so this isn't just forward-looking.
- **Docker image**: SBOM + provenance attestation attached directly to the image (`docker buildx imagetools
  inspect` / `docker scout sbom`), but **forward-only, from the first release after 6.8.1**. Unlike the ZIP,
  this can't be retrofitted onto an already-published image tag without rebuilding and re-pushing it, which
  changes its digest - not something we do to images that have already shipped. The docs say this explicitly
  rather than implying every version's image has one.

Deliberately does **not** point people at browsing the blob storage container directly for the ZIP itself - only
the SBOM's own URL is given directly; the release download should still go through the normal download page.

## What's unchanged

The "Firely OSS License" section (the Hl7.Fhir.* license reproduction) is untouched - that's a separate,
still-required legal notice for a Firely-authored dependency, not part of the exhaustive third-party list being
replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVOPS-772]: https://firely.atlassian.net/browse/DEVOPS-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEVOPS-811]: https://firely.atlassian.net/browse/DEVOPS-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ