### PR TITLE
Update documentation for Firely Server 6.9.0 .NET 10 migration

### DIFF
--- a/connecting_data_sources/firely-server-ingest.rst
+++ b/connecting_data_sources/firely-server-ingest.rst
@@ -40,7 +40,7 @@ The tool supports ingestion into SQL Server and MongoDB databases or ingestion t
 
 Installation
 ------------
-To install the tool, you first need to have .NET Core SDK v8.x installed on your computer. You can download it `here <https://dotnet.microsoft.com/en-us/download>`__. Once it is installed, execute the following command:
+To install the tool, you first need to have .NET SDK v10.x installed on your computer (FSI versions older than 6.9.0 require .NET SDK v8.x). You can download it `here <https://dotnet.microsoft.com/en-us/download>`__. Once it is installed, execute the following command:
 
 ::
 
@@ -640,7 +640,7 @@ Specify a custom settings file **/path/to/your/custom/settings/appsettings.insta
   * FSI installation folder |br|
     e.g. ``C:\Users\Bob\.dotnet\tools``  
   * FSI installation ``dll`` folder |br| 
-    e.g. ``C:\Users\Bob\.dotnet\tools\.store\firely.server.ingest\version\firely.server.ingest\version\tools\net8.0\any``
+    e.g. ``C:\Users\Bob\.dotnet\tools\.store\firely.server.ingest\version\firely.server.ingest\version\tools\net10.0\any``
 
 Run the import for files located in directory **/path/to/your/input/files** and its subdirectories using license file **/path/to/your/license/fsi-license.json** targeting the database defined by the connection string. In case a resource being imported already exists in the target database, it gets skipped.
 

--- a/facade/prerequisites.rst
+++ b/facade/prerequisites.rst
@@ -10,9 +10,10 @@ Prerequisites and Preparations
    #. get a free community edition at https://www.visualstudio.com/downloads/
    #. be sure to select the components for C# ASP.NET Core web development
 
-* .NET Core 2.0 SDK, from https://www.microsoft.com/net/download/windows
+* .NET 10 SDK, from https://dotnet.microsoft.com/en-us/download/dotnet/10.0
 
    #. this is probably installed along with the latest Visual Studio, but needed if your VS is not up-to-date.
+   #. Firely Server targets ``net10.0`` as of version 6.9.0, so your facade project has to target ``net10.0`` as well. For Firely Server 6.8.x and older, target ``net8.0`` and use the .NET 8 SDK instead.
 
 * SQL Server 2012 or newer:
 

--- a/getting_started/getting_started.rst
+++ b/getting_started/getting_started.rst
@@ -59,9 +59,13 @@ Running Firely Server
 
 .. important:: 
 	
-	The next step assumes you have a .NET Core environment installed. If not, please 
-	`download and install <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>`_ **ASP.NET Core Runtime 8.x.xx Hosting Bundle** before you continue.
+	The next step assumes you have a .NET environment installed. If not, please
+	`download and install <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>`_ **ASP.NET Core Runtime 10.x.xx Hosting Bundle** before you continue.
 	Choose the latest security patch to mitigate security issues in previous versions.
+
+	Firely Server requires .NET 10 as of version 6.9.0. Older releases require
+	`.NET 8 <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>`_ (Firely Server 5.7.0 up to and including 6.8.x)
+	or .NET 6 (Firely Server 5.6.x and older).
 
 When you have completed your configuration changes, start the server.
 Open a command prompt or Powershell, navigate to your working directory and execute:

--- a/reference/custom_plugins/custom_plugins.rst
+++ b/reference/custom_plugins/custom_plugins.rst
@@ -15,6 +15,12 @@ Please have a look at the :ref:`architecture` to see how plugins fit in the Fire
 
 A working example of a custom plugin is the :ref:`$document operation <feature_documentoperation>`, which generates a document bundle from a resource.
 
+.. note::
+
+  A plugin has to target the same .NET version as the Firely Server it is loaded into. As of Firely Server 6.9.0
+  that is ``net10.0`` (C# 14); Firely Server 5.7.0 up to and including 6.8.x target ``net8.0``. When upgrading to
+  Firely Server 6.9.0 or later, recompile your plugins against ``net10.0``.
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:

--- a/releasenotes/upgrade.rst
+++ b/releasenotes/upgrade.rst
@@ -14,6 +14,13 @@ This page describes the general process for each situation. Please refer to the 
 
    In all cases, pay attention to the import of new conformance resources - especially if you have multiple instances of Firely Server running. See :ref:`vonk_conformance_instances` for details.
 
+.. attention::
+
+   Firely Server 6.9.0 and later run on **.NET 10**, whereas 5.7.0 up to and including 6.8.x run on .NET 8. When upgrading
+   across that boundary, install the `.NET 10 runtime <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>`_ (the ASP.NET Core
+   Runtime Hosting Bundle on Windows/IIS) before starting the new version, and recompile any custom plugins and Facade projects
+   against ``net10.0``. The Docker images are already based on .NET 10, so no action is needed there.
+
 .. _upgrade_server: 
 
 Upgrading Firely Server

--- a/setting_up_firely_server/deployment/azureWebApp.rst
+++ b/setting_up_firely_server/deployment/azureWebApp.rst
@@ -19,7 +19,7 @@ Deployment
    .. image:: ../../images/Azure_01_CreateWebApp.png
       :align: center
 
-#. Choose a name for the webapp, we will use the placeholder `<firely-server-app>`, fill in an existing resource group or create a new one, unselect the unique secure hostname, select Linux for the operation system (OS), use `.Net 8` for the runtime stack and choose a region close to you:
+#. Choose a name for the webapp, we will use the placeholder `<firely-server-app>`, fill in an existing resource group or create a new one, unselect the unique secure hostname, select Linux for the operation system (OS), use `.NET 10` for the runtime stack and choose a region close to you:
 
    .. image:: ../../images/Azure_02_ChooseName.png
       :align: center

--- a/setting_up_firely_server/deployment/binaries.rst
+++ b/setting_up_firely_server/deployment/binaries.rst
@@ -9,7 +9,8 @@ Afterwards it is possible to run Firely Server as described in the :ref:`Basic i
 The necessary files can be downloaded as zip files. All versions (incl. historic versions) can be accessed `here <https://downloads.fire.ly/firely-server/versions/>`_.
 
 Please consider running a :ref:`reverse proxy <deploy_reverseProxy>` when running Firely Server natively.
-Firely Server depends on the .NET Core platform and is therefore cross-platform in all supported `environments <https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md>`_.
+Firely Server depends on the .NET platform and is therefore cross-platform in all supported `environments <https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md>`_.
+As of Firely Server 6.9.0 the .NET 10 runtime is required; earlier releases (5.7.0 up to and including 6.8.x) require .NET 8.
 
 For a production usage, Microsoft SQL Server or MongoDB need to be installed in the same environment in addition to Firely Server.
 
@@ -22,7 +23,7 @@ Firely Server is a high-performance FHIR server designed for scalability and rel
 
 **Deployment Options & Operating System:**
   
-Firely Server is supported on all platforms supported by the `.NET framework <https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md>`_.
+Firely Server is supported on all platforms supported by `.NET 10 <https://github.com/dotnet/core/blob/main/release-notes/10.0/supported-os.md>`_.
 In practice, the choice of operating system should align with your team's operational expertise and familiarity with the platform.
 There are no limitations regarding any hypervisor being used when using a virtual machine instead of a physical server.
 

--- a/setting_up_firely_server/deployment/reverseproxy/iis.rst
+++ b/setting_up_firely_server/deployment/reverseproxy/iis.rst
@@ -42,7 +42,7 @@ Prerequisites
    Web Deploy on the hosting system. To install Web Deploy, you can use the Web Platform Installer 
    (https://www.microsoft.com/web/downloads/platform.aspx).
 
-6. Install the `.NET Core Runtime & Hosting bundle <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>`_ on the hosting system. After installing it, you may need to do a “net stop was /y” and “net start w3svc” to ensure all the changes are picked up for IIS. The bundle installs the .NET Core Runtime, .NET Core Library, and the ASP.NET Core Module. ASP.NET Core Module (ANCM) allows you to run ASP.NET Core applictions using Kestrel behind IIS. For more information about ANCM check https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/aspnet-core-module
+6. Install the `.NET 10 Runtime & Hosting bundle <https://dotnet.microsoft.com/en-us/download/dotnet/10.0>`_ on the hosting system (Firely Server releases older than 6.9.0 need the `.NET 8 <https://dotnet.microsoft.com/en-us/download/dotnet/8.0>`_ bundle instead). After installing it, you may need to do a “net stop was /y” and “net start w3svc” to ensure all the changes are picked up for IIS. The bundle installs the .NET Runtime, the .NET Library, and the ASP.NET Core Module. ASP.NET Core Module (ANCM) allows you to run ASP.NET Core applictions using Kestrel behind IIS. For more information about ANCM check https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/aspnet-core-module
 
 6. Prepare binaries. You can either download the binaries for Firely Server (see :ref:`vonk_getting_started`), or create your own solution by building a facade.
 


### PR DESCRIPTION
## Summary
This PR updates all documentation to reflect the migration of Firely Server 6.9.0 to .NET 10, replacing references to .NET Core 8.x throughout the codebase.

## Key Changes
- **Runtime Requirements**: Updated all references from .NET Core 8.x to .NET 10 as the primary runtime requirement for Firely Server 6.9.0 and later
- **Backward Compatibility Notes**: Added clear guidance that Firely Server 5.7.0 through 6.8.x require .NET 8, while 5.6.x and older require .NET 6
- **Custom Plugins**: Added note requiring plugins to target `net10.0` when upgrading to Firely Server 6.9.0, matching the server's target framework
- **Facade Projects**: Updated prerequisites to require .NET 10 SDK and clarified that facade projects must target `net10.0` for Firely Server 6.9.0+
- **Deployment Guides**: Updated Azure Web App, IIS, and binary deployment documentation to reference .NET 10 runtime bundles
- **Firely Server Ingest (FSI)**: Updated installation instructions to require .NET SDK v10.x for FSI 6.9.0+, with backward compatibility note for older versions
- **Platform Support**: Updated supported environments links from .NET 8.0 to .NET 10.0 release notes

## Notable Details
- All changes maintain backward compatibility information, clearly documenting which versions require which .NET runtime
- Updated terminology from ".NET Core" to ".NET" where appropriate
- Consistent messaging across getting started, upgrade, deployment, and plugin documentation

https://claude.ai/code/session_012NKcuB5ApCB8arWfvNUeZm